### PR TITLE
Use portable shebang, fail at error

### DIFF
--- a/backup.sh
+++ b/backup.sh
@@ -1,4 +1,6 @@
-#! /bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
+
 #zrzut baz danych
 for DB in $(mysql -e 'show databases' -s --skip-column-names); do
     mysqldump $DB | gzip -c > ./bak/$DB-backup_$(date +%F-%H_%M).sql.gz;


### PR DESCRIPTION
1. Use portable shebang
2. Fail fast. Script will fail on any command error.